### PR TITLE
 Adding no-op may_panic macro for documentation purpose

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,17 @@ tempfile = "3.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
+
+[[example]]
+name = "bin"
+crate-type = ["bin"]
+
+[[example]]
+name = "lib"
+crate-type = ["lib"]
+
+[profile.dev]
+opt-level = 1
+
+[profile.test]
+opt-level = 1

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ _panic_demo..demo..__NoPanic$u20$as$u20$core..ops..drop..Drop$GT$4drop17h72f8f42
 The error is not stellar but notice the ERROR\[no-panic\] part at the end that
 provides the name of the offending function.
 
+In addition there is a no-op `may_panic` macro, which demonstrates to the 
+consumer that a given function may panic in certain situations.
+
 *Compiler support: requires rustc 1.31+*
 
 <br>

--- a/examples/bin.rs
+++ b/examples/bin.rs
@@ -1,0 +1,26 @@
+//! Usage for no_panic in binaries.
+//! Requires:
+//! ```toml
+//! [profile.dev]
+//! opt-level = 1
+//! ```
+//! Run using:
+//! `cargo run --example bin`
+
+use no_panic::no_panic;
+
+/// No link error
+#[no_panic]
+fn demo(s: &str) -> Option<&str> {
+    s.get(1..)
+}
+
+// /// Link error
+// #[no_panic]
+// pub fn demo(s: &str) -> Option<&str> {
+//     Some(&s[1..])
+// }
+
+fn main() {
+    println!("{}", demo("input string").unwrap());
+}

--- a/examples/bin.rs
+++ b/examples/bin.rs
@@ -7,7 +7,7 @@
 //! Run using:
 //! `cargo run --example bin`
 
-use no_panic::no_panic;
+use no_panic::{no_panic, may_panic};
 
 /// No link error
 #[no_panic]
@@ -21,6 +21,12 @@ fn demo(s: &str) -> Option<&str> {
 //     Some(&s[1..])
 // }
 
+#[may_panic]
+fn demo_may_panic(s: &str) -> &str {
+    &s[1..]
+}
+
 fn main() {
     println!("{}", demo("input string").unwrap());
+    println!("{}", demo_may_panic("input string"));
 }

--- a/examples/lib.rs
+++ b/examples/lib.rs
@@ -1,0 +1,27 @@
+//! Usage for no_panic in libraries.
+//! Requires:
+//! ```toml
+//! [profile.test]
+//! opt-level = 1
+//! ```
+//! Run using:
+//! `cargo test --example lib`
+
+use no_panic::no_panic;
+
+/// No link error
+#[no_panic]
+pub fn demo(s: &str) -> Option<&str> {
+    s.get(1..)
+}
+
+// /// Link error
+// #[no_panic]
+// pub fn demo(s: &str) -> Option<&str> {
+//     Some(&s[1..])
+// }
+
+#[test]
+fn no_panic() {
+    let _ = demo("aaa");
+}

--- a/examples/lib.rs
+++ b/examples/lib.rs
@@ -7,7 +7,7 @@
 //! Run using:
 //! `cargo test --example lib`
 
-use no_panic::no_panic;
+use no_panic::{no_panic, may_panic};
 
 /// No link error
 #[no_panic]
@@ -21,7 +21,13 @@ pub fn demo(s: &str) -> Option<&str> {
 //     Some(&s[1..])
 // }
 
+#[may_panic]
+fn demo_may_panic(s: &str) -> &str {
+    &s[1..]
+}
+
 #[test]
 fn no_panic() {
     let _ = demo("aaa");
+    let _ = demo_may_panic("aaa");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,9 @@
 //!
 //! The error is not stellar but notice the ERROR\[no-panic\] part at the end
 //! that provides the name of the offending function.
+//! 
+//! In addition there is a no-op `may_panic` macro, which demonstrates to the 
+//! consumer that a given function may panic in certain situations.
 //!
 //! *Compiler support: requires rustc 1.31+*
 //!
@@ -201,4 +204,9 @@ pub fn no_panic(args: TokenStream, function: TokenStream) -> TokenStream {
     }));
 
     TokenStream::from(quote!(#function))
+}
+
+#[proc_macro_attribute]
+pub fn may_panic(_args: TokenStream, function: TokenStream) -> TokenStream {
+    function
 }


### PR DESCRIPTION
Depends on #23 
Adds a no-op macro described in #17 