### PR TITLE
Preserve original input item on parse error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,14 +126,27 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
-use syn::parse::Nothing;
-use syn::{parse_macro_input, parse_quote, Attribute, FnArg, Ident, ItemFn, PatType, ReturnType};
+use syn::parse::{Nothing, Result};
+use syn::{parse_quote, Attribute, FnArg, Ident, ItemFn, PatType, ReturnType};
 
 #[proc_macro_attribute]
 pub fn no_panic(args: TokenStream, input: TokenStream) -> TokenStream {
-    parse_macro_input!(args as Nothing);
-    let function = parse_macro_input!(input as ItemFn);
-    expand_no_panic(function).into()
+    let args = TokenStream2::from(args);
+    let input = TokenStream2::from(input);
+    let expanded = match parse(args, input.clone()) {
+        Ok(function) => expand_no_panic(function),
+        Err(parse_error) => {
+            let compile_error = parse_error.to_compile_error();
+            quote!(#compile_error #input)
+        }
+    };
+    TokenStream::from(expanded)
+}
+
+fn parse(args: TokenStream2, input: TokenStream2) -> Result<ItemFn> {
+    let function: ItemFn = syn::parse2(input)?;
+    let _: Nothing = syn::parse2::<Nothing>(args)?;
+    Ok(function)
 }
 
 fn expand_no_panic(mut function: ItemFn) -> TokenStream2 {

--- a/tests/ui/trait-fn.stderr
+++ b/tests/ui/trait-fn.stderr
@@ -3,9 +3,3 @@ error: expected curly braces
   |
 5 |     fn f();
   |           ^
-
-error[E0407]: method `f` is not a member of trait `Trait`
- --> tests/ui/trait-fn.rs:9:5
-  |
-9 |     fn f() {}
-  |     ^^^^^^^^^ not a member of trait `Trait`


### PR DESCRIPTION
Example:

```rust
trait Trait {
    #[no_panic]
    fn f();
}

impl Trait for i32 {
    fn f() {}
}
```

Before:

```console
error: expected curly braces
   --> src/lib.rs:294:11
    |
294 |     fn f();
    |           ^

error[E0407]: method `f` is not a member of trait `Trait`
   --> src/lib.rs:298:5
    |
298 |     fn f() {}
    |     ^^^^^^^^^ not a member of trait `Trait`
```

After:

```console
error: expected curly braces
   --> src/lib.rs:294:11
    |
294 |     fn f();
    |           ^
```