### PR TITLE
[BUG] test with async/.await

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -193,6 +193,26 @@ assert_no_panic! {
 
         fn main() {}
     }
+
+    mod test_async_await {
+        pub struct S;
+
+        async fn f1() {}
+
+        #[no_panic]
+        async fn f2() {
+            f1().await
+        }
+
+        impl S {
+            #[no_panic]
+            async fn f(&mut self) {
+                f1().await;
+            }
+        }
+
+        fn main() {}
+    }
 }
 
 assert_link_error! {


### PR DESCRIPTION
Seems to trigger failure as well.

Thanks for your help with the other issues.

Found these when trying no-panic on some Tokio functions.