### PR TITLE
Add test that requires the nested closure to be written with non-inferred return type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
 use syn::parse::{Error, Nothing, Result};
-use syn::{parse_quote, Attribute, FnArg, Ident, ItemFn, Pat, PatType, ReturnType};
+use syn::{parse_quote, Attribute, FnArg, Ident, ItemFn, Pat, PatType};
 
 #[proc_macro_attribute]
 pub fn no_panic(args: TokenStream, input: TokenStream) -> TokenStream {
@@ -195,10 +195,6 @@ fn expand_no_panic(mut function: ItemFn) -> TokenStream2 {
         function.attrs.push(parse_quote!(#[inline]));
     }
 
-    let ret = match &function.sig.output {
-        ReturnType::Default => quote!(-> ()),
-        output @ ReturnType::Type(..) => quote!(#output),
-    };
     let stmts = function.block.stmts;
     let message = format!(
         "\n\nERROR[no-panic]: detected panic in function `{}`\n",
@@ -218,7 +214,7 @@ fn expand_no_panic(mut function: ItemFn) -> TokenStream2 {
             }
         }
         let __guard = __NoPanic;
-        let __result = (move || #ret {
+        let __result = (move || {
             #move_self
             #(
                 let #arg_pat = #arg_val;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -193,6 +193,15 @@ assert_no_panic! {
 
         fn main() {}
     }
+
+    mod test_deref_coercion {
+        #[no_panic]
+        pub fn f(s: &str) -> &str {
+            &s
+        }
+
+        fn main() {}
+    }
 }
 
 assert_link_error! {


### PR DESCRIPTION
Currently no-panic's implementation is generating an immediately invoked closure like:

```rust
let __result = (move || #ret {
    ...
})();
...
__result
```

I noticed none of the existing tests were broken if the `#ret` were omitted, so this PR adds a test that is sensitive to the return type being left to inference.

The test causes the closure to capture a value of type `&'a str`. If written with an inferred return type like `move || &s`, Rust infers `move || -> &'? &'a str { &s }` which does not compile because the closure whose capture we are borrowing does not outlive the string that would need to be returned. With an explicit return type like `move || -> &str { &s }` Rust performs a deref coercion from `&&str` to `&str` _inside the closure body_ (instead of outside of it) and correctly returns `&'a str`.