### PR TITLE
support `const fn` - NAIVE WORKAROUND NOT RECOMMENDED

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -213,6 +213,13 @@ assert_no_panic! {
 
         fn main() {}
     }
+
+    mod test_const_fn {
+        #[no_panic]
+        pub const fn f() { }
+
+        fn main() {}
+    }
 }
 
 assert_link_error! {


### PR DESCRIPTION
NAIVE WORKAROUND since Rust does not seem to really support const closures. Workaround basically corresponds to this: https://github.com/dtolnay/case-studies/blob/master/function-epilogue/README.md#second-attempt

EXPECTED TO FAIL in this case:

```rs
    mod test_return_expression {
        #[no_panic]
        pub fn f(i: i32) {
            if i < 0 {
                return;
            }
        }

        fn main() {
            println!("{:?}", f(-1));
        }
    }
```