### PR TITLE
Enable rustfmt on test modules

### DIFF
--- a/tests/compiletest/mod.rs
+++ b/tests/compiletest/mod.rs
@@ -49,7 +49,7 @@ pub fn contains_panic(name: &str, code: &str) -> bool {
 }
 
 macro_rules! assert_no_panic {
-    ($(mod $name:ident { $($content:tt)* })*) => {
+    ({ $(mod $name:ident { $($content:tt)* })* }) => {
         mod no_panic {
             use crate::compiletest;
             $(
@@ -66,7 +66,7 @@ macro_rules! assert_no_panic {
 }
 
 macro_rules! assert_link_error {
-    ($(mod $name:ident { $($content:tt)* })*) => {
+    ({ $(mod $name:ident { $($content:tt)* })* }) => {
         mod link_error {
             use crate::compiletest;
             $(

--- a/tests/compiletest/mod.rs
+++ b/tests/compiletest/mod.rs
@@ -49,7 +49,7 @@ pub fn contains_panic(name: &str, code: &str) -> bool {
 }
 
 macro_rules! assert_no_panic {
-    ({ $(mod $name:ident { $($content:tt)* })* }) => {
+    ($(mod $name:ident { $($content:tt)* })*) => {
         mod no_panic {
             use crate::compiletest;
             $(
@@ -66,7 +66,7 @@ macro_rules! assert_no_panic {
 }
 
 macro_rules! assert_link_error {
-    ({ $(mod $name:ident { $($content:tt)* })* }) => {
+    ($(mod $name:ident { $($content:tt)* })*) => {
         mod link_error {
             use crate::compiletest;
             $(

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -8,7 +8,7 @@ fn ui() {
     t.compile_fail("tests/ui/*.rs");
 }
 
-assert_no_panic! {
+assert_no_panic!({
     mod test_readme {
         #[no_panic]
         fn demo(s: &str) -> &str {
@@ -245,9 +245,9 @@ assert_no_panic! {
             println!("{:?}", f(-1));
         }
     }
-}
+});
 
-assert_link_error! {
+assert_link_error!({
     mod test_readme {
         #[no_panic]
         fn demo(s: &str) -> &str {
@@ -258,4 +258,4 @@ assert_link_error! {
             println!("{}", demo("\u{1f980}input string"));
         }
     }
-}
+});

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -8,7 +8,7 @@ fn ui() {
     t.compile_fail("tests/ui/*.rs");
 }
 
-assert_no_panic!({
+assert_no_panic![
     mod test_readme {
         #[no_panic]
         fn demo(s: &str) -> &str {
@@ -241,9 +241,9 @@ assert_no_panic!({
             println!("{:?}", f(-1));
         }
     }
-});
+];
 
-assert_link_error!({
+assert_link_error![
     mod test_readme {
         #[no_panic]
         fn demo(s: &str) -> &str {
@@ -254,4 +254,4 @@ assert_link_error!({
             println!("{}", demo("\u{1f980}input string"));
         }
     }
-});
+];

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -46,9 +46,7 @@ assert_no_panic!({
         }
 
         fn main() {
-            let mut buffer = Buffer {
-                bytes: [0u8; 24],
-            };
+            let mut buffer = Buffer { bytes: [0u8; 24] };
             println!("{:?}", demo(&mut buffer));
         }
     }
@@ -66,9 +64,7 @@ assert_no_panic!({
         }
 
         fn main() {
-            let mut buffer = Buffer {
-                bytes: [0u8; 24],
-            };
+            let mut buffer = Buffer { bytes: [0u8; 24] };
             println!("{:?}", buffer.demo(""));
         }
     }
@@ -233,7 +229,7 @@ assert_no_panic!({
                 if $e < 0 {
                     return;
                 }
-            }
+            };
         }
 
         #[no_panic]


### PR DESCRIPTION
Rustfmt does not format the contents of braced macro calls, but does format parenthesized and square bracketed macro calls containing expressions. 