### PR TITLE
Disallow warnings in tests

### DIFF
--- a/tests/compiletest/mod.rs
+++ b/tests/compiletest/mod.rs
@@ -45,6 +45,8 @@ pub fn contains_panic(name: &str, code: &str) -> bool {
             prefix = std::env::consts::DLL_PREFIX,
             extension = std::env::consts::DLL_EXTENSION,
         ))
+        .arg("-D")
+        .arg("warnings")
         .status()
         .expect("failed to execute rustc");
     assert!(status.success());

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -161,7 +161,7 @@ assert_no_panic![
             #[no_panic]
             fn get_mut(&mut self) -> usize {
                 let _ = emit!({
-                    #[allow(non_local_definitions)]
+                    #[allow(unknown_lints, non_local_definitions)]
                     impl S {
                         pub fn f(self) {}
                     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -161,6 +161,7 @@ assert_no_panic![
             #[no_panic]
             fn get_mut(&mut self) -> usize {
                 let _ = emit!({
+                    #[allow(non_local_definitions)]
                     impl S {
                         pub fn f(self) {}
                     }


### PR DESCRIPTION
Fixes the following noise in the test output.

```console
running 17 tests
test no_panic::test_borrow_from_mut_self ... ok
test no_panic::test_conditional_return ... ok
test no_panic::test_conditional_return_macro ... ok
test no_panic::test_deref_coercion ... ok
test no_panic::test_lifetime_elision ... ok
test no_panic::test_method_in_impl ... ok
test no_panic::test_mut_argument ... ok
test no_panic::test_readme ... ok
test no_panic::test_receiver_lifetime_elision ... ok
test no_panic::test_ref_argument ... ok
test no_panic::test_ref_mut_argument ... ok
test no_panic::test_return_impl_trait ... ok
test no_panic::test_self_in_macro ... ok
test no_panic::test_self_in_macro_containing_fn ... warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
 --> target/debug/build/scratch-0ebf9784fbcb3dc5/out/no-panic/test_self_in_macro_containing_fn/test_self_in_macro_containing_fn.rs:5:23
  |
4 |     #[no_panic] fn get_mut(&mut self) -> usize
  |     ----------- move the `impl` block outside of this closure `<unnameable>` and up 2 bodies
5 |     { let _ = emit!({ impl S { pub fn f(self) {} } }); self.data }
  |                       ^^^^^-
  |                            |
  |                            `S` is not local
  |
  = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
  = note: `#[warn(non_local_definitions)]` on by default

warning: 1 warning emitted

ok
test no_panic::test_self_with_std_pin ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.21s
```