### PR TITLE
Propagate attributes on function argument to captured local

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -244,6 +244,14 @@ assert_no_panic![
             println!("{:?}", f(-1));
         }
     }
+
+    mod test_argument_attribute {
+        #[deny(unused_variables)]
+        #[no_panic]
+        pub fn f(#[allow(unused_variables)] arg: i32) {}
+
+        fn main() {}
+    }
 ];
 
 assert_link_error![


### PR DESCRIPTION
This makes `allow` and `cfg` attributes work on function arguments.